### PR TITLE
Fix typo in load-image.js

### DIFF
--- a/src/load-image.js
+++ b/src/load-image.js
@@ -11,7 +11,7 @@ function loadImage(url) {
     image.onerror = function() {
       let message =
         'Could not load image at ' + url
-      reject(new Error(msg))
+      reject(new Error(message))
     }
 
     image.src = url


### PR DESCRIPTION
Fixed typo so that reject on Line 14 passes the correct 'message' variable, instead of non-existent 'msg' variable.